### PR TITLE
Wrong sizeof() was returning size of a pointer.

### DIFF
--- a/inc/util.h
+++ b/inc/util.h
@@ -58,7 +58,7 @@
 // 255 is the maximum bucket length
 #define MAX_URI_SIZE \
     ((sizeof("https:///") - 1) + S3_MAX_HOSTNAME_SIZE + 255 + 1 +       \
-     MAX_URLENCODED_KEY_SIZE + (sizeof("?torrent" - 1)) + 1)
+     MAX_URLENCODED_KEY_SIZE + (sizeof("?torrent") - 1) + 1)
 
 // Maximum size of a canonicalized resource
 #define MAX_CANONICALIZED_RESOURCE_SIZE \


### PR DESCRIPTION
This was declaring wrong buffer size for URIs.
