### PR TITLE
Fix some non-ANSI function declaration

### DIFF
--- a/src/general.c
+++ b/src/general.c
@@ -43,7 +43,7 @@ S3Status S3_initialize(const char *userAgentInfo, int flags,
 }
 
 
-void S3_deinitialize()
+void S3_deinitialize(void)
 {
     if (--initializeCountG) {
         return;

--- a/src/request.c
+++ b/src/request.c
@@ -1117,7 +1117,7 @@ S3Status request_api_initialize(const char *userAgentInfo, int flags,
 }
 
 
-void request_api_deinitialize()
+void request_api_deinitialize(void)
 {
     pthread_mutex_destroy(&requestStackMutexG);
 

--- a/src/s3.c
+++ b/src/s3.c
@@ -144,7 +144,7 @@ static char putenvBufG[256];
 
 // util ----------------------------------------------------------------------
 
-static void S3_init()
+static void S3_init(void)
 {
     S3Status status;
     const char *hostname = getenv("S3_HOSTNAME");
@@ -158,7 +158,7 @@ static void S3_init()
 }
 
 
-static void printError()
+static void printError(void)
 {
     if (statusG < S3StatusErrorAccessDenied) {
         fprintf(stderr, "\nERROR: %s\n", S3_get_status_name(statusG));
@@ -680,7 +680,7 @@ static int convert_simple_acl(char *aclXml, char *ownerId,
     return 1;
 }
 
-static int should_retry()
+static int should_retry(void)
 {
     if (retriesG--) {
         // Sleep before next retry; start out with a 1 second sleep


### PR DESCRIPTION
This pull request adds `void` in case no function parameters are declared.

This was originally submitted to Bryan upstream as a part of PR #5 , and it's broken out into its own pull request here for further review. 

 @dalgaaf originally submitted this to Ceph as part of https://github.com/ceph/libs3/pull/2 , reviewed/merged by @liewegas. Sage, Danny: do we need this in? Bryan was hoping for a bit more explanation since this is an older convention.