### PR TITLE
Fixing errors caused by #14

### DIFF
--- a/GNUmakefile.mingw
+++ b/GNUmakefile.mingw
@@ -215,7 +215,8 @@ libs3: $(LIBS3_SHARED) $(BUILD)/lib/libs3.a
 LIBS3_SOURCES := src/acl.c src/bucket.c src/error_parser.c src/general.c \
                  src/object.c src/request.c src/request_context.c \
                  src/response_headers_handler.c src/service_access_logging.c \
-                 src/service.c src/simplexml.c src/util.c src/mingw_functions.c
+                 src/service.c src/simplexml.c src/util.c src/multipart.c \
+                 src/mingw_functions.c
 
 $(LIBS3_SHARED): $(LIBS3_SOURCES:src/%.c=$(BUILD)/obj/%.o)
 	$(QUIET_ECHO) $@: Building dynamic library

--- a/GNUmakefile.osx
+++ b/GNUmakefile.osx
@@ -223,7 +223,7 @@ libs3: $(LIBS3_SHARED) $(LIBS3_SHARED_MAJOR) $(BUILD)/lib/libs3.a
 LIBS3_SOURCES := src/acl.c src/bucket.c src/error_parser.c src/general.c \
                  src/object.c src/request.c src/request_context.c \
                  src/response_headers_handler.c src/service_access_logging.c \
-                 src/service.c src/simplexml.c src/util.c
+                 src/service.c src/simplexml.c src/util.c src/multipart.c
 
 $(LIBS3_SHARED): $(LIBS3_SOURCES:src/%.c=$(BUILD)/obj/%.do)
 	$(QUIET_ECHO) $@: Building shared library

--- a/src/s3.c
+++ b/src/s3.c
@@ -29,7 +29,7 @@
  * calls to libs3 functions, and prints the results.
  **/
 
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 600
 #include <ctype.h>
 #include <getopt.h>
 #include <stdio.h>


### PR DESCRIPTION
Hi!
Trying to install from master on Mac Os X I experienced 2 issues. Both are caused by the recent merged push #14 

1st issue: There are 2 new warnings in s3.c. Since flag -Werror is being used, make will fail. Those warnings are caused by the `#define _XOPEN_SOURCE 500`. Fixed this replacing 500 by 600 (as owner suggested in the #14 pull request discusion). This is caused by old POSIX standard.

2nd issue: #14 only added the new multipart.c to GNUmakefile, but not to GNUmakefile.osx and GNUmakefile.mingw. Just added multipart.c to both.

Sample error triggered by issue 1:
```
Guillermos-MBP:libs3 Guillermo$ sudo make -f GNUmakefile.osx DESTDIR=/usr/local/ install
[...]
build/obj/s3.o: Compiling object
src/s3.c:552:5: error: implicitly declaring library function 'snprintf' with type 'int (char *, unsigned long, const char *, ...)'
      [-Werror]
    snprintf(putenvBufG, sizeof(putenvBufG), "TZ=UTC");
    ^
src/s3.c:552:5: note: include the header <stdio.h> or explicitly provide a declaration for 'snprintf'
src/s3.c:1605:50: error: implicitly declaring library function 'strdup' with type 'char *(const char *)' [-Werror]
            manager->etags[handlePartsStart+i] = strdup(part->eTag);
                                                 ^
src/s3.c:1605:50: note: include the header <string.h> or explicitly provide a declaration for 'strdup'
2 errors generated.
make: *** [build/obj/s3.o] Error 1
```


Sample error triggered by issue 2:
 ```
Undefined symbols for architecture x86_64:
  "_S3_abort_multipart_upload", referenced from:
      _main in s3.o
  "_S3_complete_multipart_upload", referenced from:
      _main in s3.o
  "_S3_initiate_multipart", referenced from:
      _main in s3.o
  "_S3_list_multipart_uploads", referenced from:
      _main in s3.o
  "_S3_list_parts", referenced from:
      _main in s3.o
  "_S3_upload_part", referenced from:
      _main in s3.o
```