### PR TITLE
Fix corrupted request time headers due to thread-unsafe gmtime

### DIFF
--- a/src/request.c
+++ b/src/request.c
@@ -342,7 +342,8 @@ static S3Status compose_amz_headers(const RequestParams *params,
     // Add the x-amz-date header
     time_t now = time(NULL);
     char date[64];
-    strftime(date, sizeof(date), "%a, %d %b %Y %H:%M:%S GMT", gmtime(&now));
+    struct tm gmt;
+    strftime(date, sizeof(date), "%a, %d %b %Y %H:%M:%S GMT", gmtime_r(&now, &gmt));
     headers_append(1, "x-amz-date: %s", date);
 
     if (params->httpRequestType == HttpRequestTypeCOPY) {
@@ -459,8 +460,9 @@ static S3Status compose_standard_headers(const RequestParams *params,
     // Expires
     if (params->putProperties && (params->putProperties->expires >= 0)) {
         time_t t = (time_t) params->putProperties->expires;
+        struct tm gmt;
         strftime(values->expiresHeader, sizeof(values->expiresHeader),
-                 "Expires: %a, %d %b %Y %H:%M:%S UTC", gmtime(&t));
+                 "Expires: %a, %d %b %Y %H:%M:%S UTC", gmtime_r(&t, &gmt));
     }
     else {
         values->expiresHeader[0] = 0;
@@ -470,9 +472,10 @@ static S3Status compose_standard_headers(const RequestParams *params,
     if (params->getConditions &&
         (params->getConditions->ifModifiedSince >= 0)) {
         time_t t = (time_t) params->getConditions->ifModifiedSince;
+        struct tm gmt;
         strftime(values->ifModifiedSinceHeader,
                  sizeof(values->ifModifiedSinceHeader),
-                 "If-Modified-Since: %a, %d %b %Y %H:%M:%S UTC", gmtime(&t));
+                 "If-Modified-Since: %a, %d %b %Y %H:%M:%S UTC", gmtime_r(&t, &gmt));
     }
     else {
         values->ifModifiedSinceHeader[0] = 0;
@@ -482,9 +485,10 @@ static S3Status compose_standard_headers(const RequestParams *params,
     if (params->getConditions &&
         (params->getConditions->ifNotModifiedSince >= 0)) {
         time_t t = (time_t) params->getConditions->ifNotModifiedSince;
+        struct tm gmt;
         strftime(values->ifUnmodifiedSinceHeader,
                  sizeof(values->ifUnmodifiedSinceHeader),
-                 "If-Unmodified-Since: %a, %d %b %Y %H:%M:%S UTC", gmtime(&t));
+                 "If-Unmodified-Since: %a, %d %b %Y %H:%M:%S UTC", gmtime_r(&t, &gmt));
     }
     else {
         values->ifUnmodifiedSinceHeader[0] = 0;


### PR DESCRIPTION
Howdy,

I use libs3 w/pthreads in my app, and was seeing frequent requests whose time was Jan 1, 1970.  After some digging I found that it's using a stdlib routine which is not thread safe to grab the time.  Replacing w/a thread-safe version fixes the multithreaded case and works fine for single-threaded as well.  The commit message is below.

Thanks,
-Earle F. Philhower, III

gmtime() is used to convert the system time to GMT so that the S3
request time can be appended to the headers.  It returns a pointer
to a library static struct tm.  This works fine in the single-
threaded case, but can cause request times to be corrupted should
libs3 be called in a multithreaded use case.

Replaces the gmtime() with a gmtime_r() call which takes a pointer
to a thread-local struct tm, fixing the issue.