### PR TITLE
Verify peer

### DIFF
--- a/inc/libs3.h
+++ b/inc/libs3.h
@@ -211,6 +211,11 @@ extern "C" {
  * Microsoft Windows platforms.
  **/
 #define S3_INIT_WINSOCK                    1
+/**
+ * This constant is used by the S3_initialize() function, to verify
+ * the peer SSL certificate by default.
+ */
+#define S3_INIT_VERIFY_PEER                2
 
 
 /**
@@ -1583,6 +1588,18 @@ S3Status S3_get_request_context_fdsets(S3RequestContext *requestContext,
  *         could wait a shorter time if they wish, but not longer.
  **/
 int64_t S3_get_request_context_timeout(S3RequestContext *requestContext);
+
+/**
+ * This function enables SSL peer certificate verification on a per-request
+ * context basis. If this is called, the context's value of verifyPeer will
+ * be used when processing requests. Otherwise, the default set by the
+ * flags to S3_initialize() are used.
+ *
+ * @param requestContext the S3RequestContext to set the verifyPeer flag on.
+ * @param verifyPeer a boolean value indicating whether to verify the peer
+ *        certificate or not.
+ */
+void S3_set_request_context_verify_peer(S3RequestContext *requestContext, int verifyPeer);
 
 
 /** **************************************************************************

--- a/inc/request_context.h
+++ b/inc/request_context.h
@@ -32,6 +32,9 @@
 struct S3RequestContext
 {
     CURLM *curlm;
+    
+    int verifyPeerSet;
+    long verifyPeer;
 
     struct Request *requests;
 };

--- a/src/bucket.c
+++ b/src/bucket.c
@@ -677,13 +677,13 @@ void S3_list_bucket(const S3BucketContext *bucketContext, const char *prefix,
 
 
     int amp = 0;
-    if (prefix) {
+    if (prefix && *prefix) {
         safe_append("prefix", prefix);
     }
-    if (marker) {
+    if (marker && *marker) {
         safe_append("marker", marker);
     }
-    if (delimiter) {
+    if (delimiter && *delimiter) {
         safe_append("delimiter", delimiter);
     }
     if (maxkeys) {

--- a/src/multipart.c
+++ b/src/multipart.c
@@ -862,19 +862,19 @@ void S3_list_multipart_uploads(S3BucketContext *bucketContext, const char *prefi
     
     
         int amp = 0;
-        if (prefix) {
+        if (prefix && *prefix) {
             safe_append("prefix", prefix);
         }
-        if (keymarker) {
+        if (keymarker && *keymarker) {
             safe_append("key-marker", keymarker);
         }
-        if (delimiter) {
+        if (delimiter && *delimiter) {
             safe_append("delimiter", delimiter);
         }
-        if (uploadidmarker) {
+        if (uploadidmarker && *uploadidmarker) {
             safe_append("upload-id-marker", uploadidmarker);
         }
-        if (encodingtype) {
+        if (encodingtype && *encodingtype) {
             safe_append("encoding-type", encodingtype);
         }
         if (maxuploads) {
@@ -991,10 +991,10 @@ void S3_list_parts(S3BucketContext *bucketContext, const char *key,
         snprintf(subResource, 512, "uploadId=%s", uploadid);   
         int amp = 0;
 
-        if (partnumbermarker) {
+        if (partnumbermarker && *partnumbermarker) {
             safe_append("part-number-marker", partnumbermarker);
         }
-        if (encodingtype) {
+        if (encodingtype && *encodingtype) {
             safe_append("encoding-type", encodingtype);
         }
         if (maxparts) {

--- a/src/request.c
+++ b/src/request.c
@@ -1360,6 +1360,7 @@ S3Status request_curl_code_to_status(CURLcode code)
         return S3StatusConnectionFailed;
     case CURLE_PARTIAL_FILE:
         return S3StatusOK;
+    case CURLE_PEER_FAILED_VERIFICATION:
     case CURLE_SSL_CACERT:
         return S3StatusServerFailedVerification;
     default:

--- a/src/request.c
+++ b/src/request.c
@@ -106,6 +106,9 @@ typedef struct RequestComputedValues
 
     // Authorization header
     char authorizationHeader[128];
+
+    // Host header
+    char hostHeader[128];
 } RequestComputedValues;
 
 
@@ -433,6 +436,22 @@ static S3Status compose_standard_headers(const RequestParams *params,
             values-> destField[0] = 0;                                      \
         }                                                                   \
     } while (0)
+
+    // Host
+    if (params->bucketContext.uriStyle == S3UriStyleVirtualHost) {
+        const char *requestHostName = params->bucketContext.hostName
+                ? params->bucketContext.hostName : defaultHostNameG;
+
+        size_t len = snprintf(values->hostHeader, sizeof(values->hostHeader), "Host: %s.%s",
+                        params->bucketContext.bucketName, requestHostName);
+        if (len >= sizeof(values->hostHeader)) {
+            return S3StatusUriTooLong;
+        }
+        while (is_blank(values->hostHeader[len])) {
+            len--;
+        }
+        values->hostHeader[len] = 0;
+    }
 
     // Cache-Control
     do_put_header("Cache-Control: %s", cacheControl, cacheControlHeader,
@@ -779,7 +798,15 @@ static S3Status compose_uri(char *buffer, int bufferSize,
     if (bucketContext->bucketName && 
         bucketContext->bucketName[0]) {
         if (bucketContext->uriStyle == S3UriStyleVirtualHost) {
-            uri_append("%s.%s", bucketContext->bucketName, hostName);
+            if (strchr(bucketContext->bucketName, '.') == NULL) {
+                uri_append("%s.%s", bucketContext->bucketName, hostName);
+            }
+            else {
+                // We'll use the hostName in the URL, and then explicitly set
+                // the Host header to match bucket.host so that host validation
+                // works.
+                uri_append("%s", hostName);
+            }
         }
         else {
             uri_append("%s/%s", hostName, bucketContext->bucketName);
@@ -804,7 +831,6 @@ static S3Status compose_uri(char *buffer, int bufferSize,
     
     return S3StatusOK;
 }
-
 
 // Sets up the curl handle given the completely computed RequestParams
 static S3Status setup_curl(Request *request,
@@ -903,6 +929,7 @@ static S3Status setup_curl(Request *request,
                                              "Transfer-Encoding:");
     }
     
+    append_standard_header(hostHeader);
     append_standard_header(cacheControlHeader);
     append_standard_header(contentTypeHeader);
     append_standard_header(md5Header);
@@ -1113,9 +1140,7 @@ S3Status request_api_initialize(const char *userAgentInfo, int flags,
     char platform[96];
     struct utsname utsn;
     if (uname(&utsn)) {
-        strncpy(platform, "Unknown", sizeof(platform));
-        // Because strncpy doesn't always zero terminate
-        platform[sizeof(platform) - 1] = 0;
+        snprintf(platform, sizeof(platform), "Unknown");
     }
     else {
         snprintf(platform, sizeof(platform), "%s%s%s", utsn.sysname, 
@@ -1139,11 +1164,12 @@ void request_api_deinitialize()
     }
 }
 
-
 void request_perform(const RequestParams *params, S3RequestContext *context)
 {
     Request *request;
     S3Status status;
+    int verifyPeerRequest = verifyPeer;
+    CURLcode curlstatus;
 
 #define return_status(status)                                           \
     (*(params->completeCallback))(status, 0, params->callbackData);     \
@@ -1193,15 +1219,18 @@ void request_perform(const RequestParams *params, S3RequestContext *context)
     if ((status = request_get(params, &computed, &request)) != S3StatusOK) {
         return_status(status);
     }
-
-    // If a RequestContext was provided, add the request to the curl multi
-    if (context) {
-        if (context->verifyPeerSet) {
-            CURLcode curlstatus;
+    if (context && context->verifyPeerSet) {
+        verifyPeerRequest = context->verifyPeerSet;
+    }
+    // Allow per-context override of verifyPeer
+    if (verifyPeerRequest != verifyPeer) {
             if ((curlstatus = curl_easy_setopt(request->curl, CURLOPT_SSL_VERIFYPEER, context->verifyPeer)) != CURLE_OK) {
                 return_status(S3StatusFailedToInitializeRequest);
             }
-        }
+    }
+
+    // If a RequestContext was provided, add the request to the curl multi
+    if (context) {
         CURLMcode code = curl_multi_add_handle(context->curlm, request->curl);
         if (code == CURLM_OK) {
             if (context->requests) {
@@ -1228,6 +1257,7 @@ void request_perform(const RequestParams *params, S3RequestContext *context)
         if ((code != CURLE_OK) && (request->status == S3StatusOK)) {
             request->status = request_curl_code_to_status(code);
         }
+
         // Finish the request, ensuring that all callbacks have been made, and
         // also releases the request
         request_finish(request);

--- a/src/request_context.c
+++ b/src/request_context.c
@@ -46,6 +46,8 @@ S3Status S3_create_request_context(S3RequestContext **requestContextReturn)
     }
 
     (*requestContextReturn)->requests = 0;
+    (*requestContextReturn)->verifyPeer = 0;
+    (*requestContextReturn)->verifyPeerSet = 0;
 
     return S3StatusOK;
 }
@@ -187,4 +189,10 @@ int64_t S3_get_request_context_timeout(S3RequestContext *requestContext)
     }
     
     return timeout;
+}
+
+void S3_set_request_context_verify_peer(S3RequestContext *requestContext, int verifyPeer)
+{
+    requestContext->verifyPeerSet = 1;
+    requestContext->verifyPeer = (verifyPeer != 0);
 }

--- a/src/s3.c
+++ b/src/s3.c
@@ -63,6 +63,7 @@ static int showResponsePropertiesG = 0;
 static S3Protocol protocolG = S3ProtocolHTTPS;
 static S3UriStyle uriStyleG = S3UriStylePath;
 static int retriesG = 5;
+static int verifyPeerG = 0;
 
 
 // Environment variables, saved as globals ----------------------------------
@@ -164,7 +165,7 @@ static void S3_init()
     S3Status status;
     const char *hostname = getenv("S3_HOSTNAME");
     
-    if ((status = S3_initialize("s3", S3_INIT_ALL, hostname))
+    if ((status = S3_initialize("s3", verifyPeerG|S3_INIT_ALL, hostname))
         != S3StatusOK) {
         fprintf(stderr, "Failed to initialize libs3: %s\n", 
                 S3_get_status_name(status));
@@ -199,6 +200,7 @@ static void usageExit(FILE *out)
 "   -s/--show-properties : show response properties on stdout\n"
 "   -r/--retries         : retry retryable failures this number of times\n"
 "                          (default is 5)\n"
+"   -v/--verify-peer     : verify peer SSL certificate (default is no)\n"
 "\n"
 "   Environment:\n"
 "\n"
@@ -739,6 +741,7 @@ static struct option longOptionsG[] =
     { "unencrypted",          no_argument,        0,  'u' },
     { "show-properties",      no_argument,        0,  's' },
     { "retries",              required_argument,  0,  'r' },
+    { "verify-peer",          no_argument,        0,  'v' },
     { 0,                      0,                  0,   0  }
 };
 
@@ -3543,7 +3546,7 @@ int main(int argc, char **argv)
     // Parse args
     while (1) {
         int idx = 0;
-        int c = getopt_long(argc, argv, "fhusr:", longOptionsG, &idx);
+        int c = getopt_long(argc, argv, "vfhusr:", longOptionsG, &idx);
 
         if (c == -1) {
             // End of options
@@ -3571,6 +3574,9 @@ int main(int argc, char **argv)
                 retriesG += *v - '0';
                 v++;
             }
+            break;
+        case 'v':
+            verifyPeerG = S3_INIT_VERIFY_PEER;
             break;
         }
         default:


### PR DESCRIPTION
This patch adds an option to enable the curl verify_peer option. It works around the s3 virtual host certificate wildcard mismatch by using the top-level s3 hostname in the URI and then explicitly setting the Host header in the request.