### PR TITLE
Fix unitialized hostHeader element - was causing random headers to be sent

### DIFF
--- a/src/request.c
+++ b/src/request.c
@@ -454,6 +454,8 @@ static S3Status compose_standard_headers(const RequestParams *params,
             len--;
         }
         values->hostHeader[len] = 0;
+    } else {
+        values->hostHeader[0] = 0;
     }
 
     // Cache-Control


### PR DESCRIPTION
There was a new request element "hostHeader" added early this year.

The patch, though, neglected to set it to a safe value if we weren't using Virtual Host URLs.  It wouls just be whatever happened to be on the stack where it was allocated.

This would result in occasional, random headers being sent to S3 depending on what was left over in memory.  Was quite a pain to debug as it doesn't always fail...I guess we have lots of 0s on the stack.

This patch just sets it to the \0 string in normal case, this way we don't add it or garbage ourselves.