### PR TITLE
Space should not be converted into plus

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -72,9 +72,6 @@ int urlEncode(char *dest, const char *src, int maxSrcSize)
             (c == ')') || (c == '/')) {
             *dest++ = c;
         }
-        else if (*src == ' ') {
-            *dest++ = '+';
-        }
         else {
             *dest++ = '%';
             *dest++ = hex[c >> 4];


### PR DESCRIPTION
Hello!

I found other S3 library doesn't seem to be doing the conversion, and if convert space to plus I upload a file with key "1+2" and then upload a file with key "1 2", will overwritte the first file, is that correct?