### PR TITLE
Issue #36 - Expires header is set incorrectly

### DIFF
--- a/src/bucket.c
+++ b/src/bucket.c
@@ -263,7 +263,7 @@ void S3_create_bucket(S3Protocol protocol, const char *accessKeyId,
         0,                                       // cacheControl
         0,                                       // contentDispositionFilename
         0,                                       // contentEncoding
-        0,                                       // expires
+       -1,                                       // expires
         cannedAcl,                               // cannedAcl
         0,                                       // metaDataCount
         0,                                       // metaData


### PR DESCRIPTION
The "Expires" field is not needed for a create bucket request and
in fact, setting it to zero can cause some S3 implementations to
fail the request because well, it has expired.

Therefore, we set the "expires" S3PutParameter of the create bucket
call to -1 in order to bypass generating this HTTP header entirely.