### PR TITLE
Origin prefix listing xml

### DIFF
--- a/src/bucket.c
+++ b/src/bucket.c
@@ -537,10 +537,11 @@ static S3Status listBucketXmlCallback(const char *elementPath,
         else if (!strcmp(elementPath, 
                          "ListBucketResult/CommonPrefixes/Prefix")) {
             int which = lbData->commonPrefixesCount;
+            size_t oldLen = lbData->commonPrefixLens[which];
             lbData->commonPrefixLens[which] +=
-                snprintf(lbData->commonPrefixes[which],
+                snprintf(lbData->commonPrefixes[which]+oldLen,
                          sizeof(lbData->commonPrefixes[which]) -
-                         lbData->commonPrefixLens[which] - 1,
+                         oldLen - 1,
                          "%.*s", dataLen, data);
             if (lbData->commonPrefixLens[which] >=
                 (int) sizeof(lbData->commonPrefixes[which])) {


### PR DESCRIPTION
I ran into a problem listing a bucket which contained prefixes that contained some characters that s3 translated into and back from xml entities (&<>). The sax parser was delivering them to the xml callback by having multiple calls to the listBucketXmlCallback, but that function was overwriting the beginning of the prefix each time it was called.
