### PR TITLE
Use git tags for dist tar.gz versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 build-debug
 
+GIT-VERSION-FILE

--- a/GIT-VERSION-GEN
+++ b/GIT-VERSION-GEN
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+error()
+{
+    echo "$*"
+    exit 1
+}
+
+# A file we can use to send version information downstream - like in .src.rpm
+VERF="GIT-VERSION-FILE"
+
+SAVED_VERSION=""
+
+# either there is a version file or we are in git, nothing else is sane... for now
+if test -f "$VERF"; then
+    SAVED_VERSION=$(awk -F ' = ' '/FULL_VERSION/ {print $NF}' "$VERF")
+    if [[ -z "$SAVED_VERSION" ]]; then
+        error "could not read version information from $VERF"
+    fi
+fi
+
+# even in saved version cases, re-run git to see if we need to update version file
+if test -d .git; then
+    # we get data like this from git describe
+    # release: v0.9.1
+    # between releases: v0.9.1-9-g94768c8
+    GIT_VERSION=$(git describe --match "v[0-9]*" HEAD)
+    # strip leading v - we only use the numbers for our version file
+    GIT_VERSION=${GIT_VERSION:1}
+else
+    # no git, require version from saved file
+    GIT_VERSION="$SAVED_VERSION"
+fi
+
+if [[ -z "$GIT_VERSION" ]]; then
+    error "could not use git to describe the version"
+fi
+
+#
+# pick up developer PKG_PATCH
+if [[ -n "$PKG_PATCH" ]]; then
+    GIT_VERSION="$GIT_VERSION-$PKG_PATCH"
+fi
+
+# version is everything before first dash, release everything after
+VERSION=$(echo "$GIT_VERSION" | cut -d'-' -f 1)
+
+# when git tells us we are at a tag, RELEASE is effectively blank
+num_dash=$(echo "$GIT_VERSION" | awk -F '-' '{print NF-1}')
+
+RELEASE=""
+if [[ $num_dash -gt 0 ]]; then
+    RELEASE=$(echo "$GIT_VERSION" | cut -d'-' -f 2-)
+fi
+
+# save it, even if the same as we read in - no harm
+if [[ "$SAVED_VERSION" != "$GIT_VERSION" ]]; then
+    cat > "$VERF" << EOF
+VERSION = $VERSION
+RELEASE = $RELEASE
+FULL_VERSION = $GIT_VERSION
+EOF
+fi

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -36,10 +36,19 @@
 
 
 # --------------------------------------------------------------------------
-# Set libs3 version number, unless it is already set.
+# Set libs3 version number using git tags and optional developer PKG_PATCH
+# environment variable
+#
 
-LIBS3_VER_MAJOR ?= 2
-LIBS3_VER_MINOR ?= 0
+# use phony .FORCE to ensure this is always regenerated
+.PHONY: .FORCE
+
+GIT-VERSION-FILE: .FORCE
+	./GIT-VERSION-GEN
+-include GIT-VERSION-FILE
+
+LIBS3_VER_MAJOR ?= $(wordlist 1,1, $(subst -, ,$(subst ., ,$(VERSION))))
+LIBS3_VER_MINOR ?= $(wordlist 2,2, $(subst -, ,$(subst ., ,$(VERSION))))
 LIBS3_VER := $(LIBS3_VER_MAJOR).$(LIBS3_VER_MINOR)
 
 
@@ -81,6 +90,8 @@ ifndef BUILD
     endif
 endif
 
+$(BUILD):
+	$(VERBOSE_SHOW) mkdir -p $(BUILD)
 
 # --------------------------------------------------------------------------
 # DESTDIR directory
@@ -314,6 +325,19 @@ ALL_SOURCES := $(LIBS3_SOURCES) s3.c testsimplexml.c
 $(foreach i, $(ALL_SOURCES), $(eval -include $(BUILD)/dep/src/$(i:%.c=%.d)))
 $(foreach i, $(ALL_SOURCES), $(eval -include $(BUILD)/dep/src/$(i:%.c=%.dd)))
 
+# --------------------------------------------------------------------------
+# tar package target
+#
+GIT_TARNAME = libs3-$(FULL_VERSION)
+GIT_TARPATH = $(BUILD)/$(GIT_TARNAME)
+
+dist: $(BUILD)
+	$(VERBOSE_SHOW) git archive --format=tar --prefix=$(GIT_TARNAME)/ HEAD^{tree} > $(GIT_TARPATH).tar
+	$(VERBOSE_SHOW) mkdir -p $(GIT_TARNAME)
+	$(VERBOSE_SHOW) cp GIT-VERSION-FILE $(GIT_TARNAME)
+	$(VERBOSE_SHOW) tar -rf $(GIT_TARPATH).tar $(GIT_TARNAME)/GIT-VERSION-FILE
+	$(VERBOSE_SHOW) rm -r $(GIT_TARNAME)
+	$(VERBOSE_SHOW) gzip -f -9 $(GIT_TARPATH).tar
 
 # --------------------------------------------------------------------------
 # Debian package target


### PR DESCRIPTION
In order to provide a much cleaner release build (RPM, tar.gz, etc)
mechanism, it is highly desirable to use git tags to drive the
versioning. This allows for much cleaner automation (git tag && git push
--tags) along with providing git tracking of these release artifact
versions.

We are taking the idea of GIT-VERSION-GEN from the upstream git
repository itself and using the dynamic GNUMakefile include of the
generated data. This populates VERSION, RELEASE and FULL_VERSION from
the latest git tag. This requires the initial tags be populated into the
repository before trying to use this change.

The latest EPEL RPM set could be tagged like this:
$ git tag -a v2.0-0.2.20150902 247ba1b

We are also adding a 'make dist' target to dump a .tar.gz that could be
used for RPM or deb builds in the future. This makes full use of the
versioning information in the GIT-VERSION-FILE and ensures that the
library is built with the same versions as are constructed in release
artifacts.
