### PR TITLE
Support older libcurl versions

### DIFF
--- a/src/request.c
+++ b/src/request.c
@@ -1372,7 +1372,11 @@ S3Status request_curl_code_to_status(CURLcode code)
         return S3StatusConnectionFailed;
     case CURLE_PARTIAL_FILE:
         return S3StatusOK;
+#if LIBCURL_VERSION_NUM >= 0x071101 /* 7.17.1 */
     case CURLE_PEER_FAILED_VERIFICATION:
+#else
+    case CURLE_SSL_PEER_CERTIFICATE:
+#endif
     case CURLE_SSL_CACERT:
         return S3StatusServerFailedVerification;
     default:


### PR DESCRIPTION
Support libcurl versions before 7.17.1 (e.g. RHEL 5 uses 7.15.5).
