### PR TITLE
Add support for AWS authorization signature version 4

### DIFF
--- a/inc/libs3.h
+++ b/inc/libs3.h
@@ -220,6 +220,13 @@ extern "C" {
  */
 #define S3_INIT_VERIFY_PEER                2
 
+/**
+ * This constant is used by the S3_initialize() function, to enable AWS
+ * signature version 4 for authorization. If this is not set in the flags
+ * passed to S3_initialize(), then the libs3 will use AWS signature version
+ * 2 to sign all requests.
+ */
+#define S3_INIT_SIGNATURE_V4               4
 
 /**
  * This convenience constant is used by the S3_initialize() function to
@@ -423,6 +430,14 @@ typedef enum
     S3UriStylePath                      = 1
 } S3UriStyle;
 
+/**
+ * S3SignatureVersion define the signature methods for AWS REST API.
+ **/
+typedef enum
+{
+    S3SignatureV2                       = 2,
+    S3SignatureV4                       = 4
+} S3SignatureVersion;
 
 /**
  * S3GranteeType defines the type of Grantee used in an S3 ACL Grant.
@@ -1436,6 +1451,21 @@ typedef struct S3AbortMultipartUploadHandler
 S3Status S3_initialize(const char *userAgentInfo, int flags,
                        const char *defaultS3HostName);
 
+/**
+ * Set the region name in the requests made to AWS S3, and it is only required
+ * when AWS signature version 4 is enabled (S3_initialize() is called with
+ * S3_INIT_SIGNATURE_V4 flag.). And it should be called immediately after the
+ * call to S3_initialize(), before any other S3 function calls. And this
+ * function is NOT thread-safe and can only be called by one thread at a time.
+ *
+ * @param regionName is a string to represent the region the library wants to
+ *        contact in all its request. If this is NULL or this function is not
+ *        called at all, the region is default to "us-east-1".
+ * @return One of:
+ *         S3StatusOK on success
+ *         S3StatusUriTooLong if regionName is longer than S3_MAX_HOSTNAME_SIZE
+ **/
+S3Status S3_set_region_name(const char *regionName);
 
 /**
  * Must be called once per program for each call to libs3_initialize().  After

--- a/test/signature/Makefile
+++ b/test/signature/Makefile
@@ -1,0 +1,4 @@
+signature: main.cpp mock.cpp
+	g++ -g -I../../inc -L../../build/lib -o signature main.cpp mock.cpp -lcurl -ls3 -lxml2 -lssl -lcrypto
+clean:
+	rm -f signature

--- a/test/signature/README
+++ b/test/signature/README
@@ -1,0 +1,10 @@
+This is a simple tool to test the libs3 signature against the AWS signature
+version 4 test-suite.
+
+You should modify src/request.c to #define S3_SERVICE "service"
+and re-build the libs3
+
+And you should download the test-suite from http://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html and then unzip it somewhere.
+
+Then you can run the test by
+./run.sh /path/to/aws-testsuite/

--- a/test/signature/main.cpp
+++ b/test/signature/main.cpp
@@ -1,0 +1,169 @@
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <curl/curl.h>
+#include <request.h>
+#include <libs3.h>
+#include <sstream>
+#include <iomanip>
+#include <stdlib.h>
+
+using namespace std;
+
+string url_encode(const string &value) {
+    ostringstream escaped;
+    escaped.fill('0');
+    escaped << hex;
+
+    for (string::const_iterator i = value.begin(), n = value.end(); i != n; ++i) {
+        string::value_type c = (*i);
+
+            // Keep alphanumeric and other accepted characters intact
+        if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~'
+            || c == '/' || c == '%' || c == '?' || c == '&' || c == '=') {
+            escaped << c;
+            continue;
+        }
+
+            // Any other characters are percent-encoded
+        escaped << uppercase;
+        escaped << '%' << setw(2) << int((unsigned char) c);
+        escaped << nouppercase;
+    }
+
+    return escaped.str();
+}
+
+#include <openssl/sha.h>
+
+string sha256(const string str)
+{
+    unsigned char hash[SHA256_DIGEST_LENGTH];
+    SHA256_CTX sha256;
+    SHA256_Init(&sha256);
+    SHA256_Update(&sha256, str.c_str(), str.size());
+    SHA256_Final(hash, &sha256);
+    stringstream ss;
+    for(int i = 0; i < SHA256_DIGEST_LENGTH; i++)
+    {
+        ss << hex << setw(2) << setfill('0') << (int)hash[i];
+    }
+    return ss.str();
+}
+
+struct RequestComputedValues;
+
+void createMockObjs(const std::string &httpVerb,
+                    const std::string &uri,
+                    const std::string &payloadhash,
+                    struct curl_slist *headers,
+                    Request **request,
+                    RequestParams **params,
+                    RequestComputedValues **values);
+void destroyMockObjs(Request *, RequestParams *, RequestComputedValues *);
+
+
+struct RequestComputedValues;
+extern "C" {
+    S3Status compose_auth4_header(Request *request,
+                                  const RequestParams *params,
+                                  const RequestComputedValues *values);
+
+    S3Status calculate_hmac_sha256(char *buf, int maxlen,int *plen,
+                                   const char *key, int keylen,
+                                   const char *msg, int msglen);
+}
+
+#if 0
+
+void print_sha256(const char *hash, int len)
+{
+    for (int i = 0; i < len; i++) {
+        printf("%02x", (unsigned char)hash[i]);
+    }
+    printf("\n");
+}
+
+int main(int argc, char **argv)
+{
+    char kdate[32],kregion[32],kservice[32],ksigning[32];
+    int len = 0;
+    string secret = "AWS4wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+    string date = "20150830";
+    calculate_hmac_sha256(kdate, 32, &len, secret.c_str(), secret.length(),
+                          date.c_str(), 8);
+    print_sha256(kdate, 32);
+    len = 0;
+    calculate_hmac_sha256(kregion, 32, &len, kdate, 32, "us-east-1", 9);
+    print_sha256(kregion, 32);
+}
+
+#endif
+#if 1
+int main(int argc, char **argv)
+{
+    if (argc != 2) {
+        std::cout << "Usage: ./signature xxx.req\n";
+        return -1;
+    }
+    S3_initialize(NULL, S3_INIT_ALL | S3_INIT_SIGNATURE_V4, NULL);
+    S3_set_region_name("us-east-1");
+    std::ifstream reqfile(argv[1]);
+    std::string httpVerb, uri, httpVersion;
+    reqfile >> httpVerb >> uri >> httpVersion;
+    while (httpVersion != "HTTP/1.1") {
+        reqfile >> httpVersion;
+    }
+    uri = std::string("https://s3.amazonaws.com") + url_encode(uri);
+    std::string line;
+    std::string header;
+    struct curl_slist *headerList = NULL;
+    std::getline(reqfile, line);
+    while (std::getline(reqfile, line)) {
+        if (line.empty()) break;
+        if (line[0] == ' ' || line[0] == '\t') {
+            header += "\r\n";
+            header += line;
+        } else {
+            if (!header.empty())
+                headerList = curl_slist_append(headerList, header.c_str());
+            header = line;
+        }
+    }
+    if (!header.empty())
+        headerList = curl_slist_append(headerList, header.c_str());
+    std::string shahash;
+    if (reqfile.bad()) {
+        std::cout << "Failed to read request file: " << argv[1] << std::endl;
+        curl_slist_free_all(headerList);
+        return -1;
+    } else if (!reqfile.eof()) {
+        std::string content((std::istreambuf_iterator<char>(reqfile)),
+                            std::istreambuf_iterator<char>());
+        shahash = sha256(content);
+    }
+#ifdef DEBUG
+    std::cout << uri << std::endl;
+    for (struct curl_slist *itr = headerList; itr != NULL; itr = itr->next) {
+        std::cout << "HEADER::" << itr->data << "::\n";
+    }
+#endif
+    Request *request;
+    RequestParams *params;
+    RequestComputedValues *values;
+    createMockObjs(httpVerb, uri, shahash, headerList, &request, &params,
+                   &values);
+    S3Status ret = compose_auth4_header(request, params, values);
+    if (ret != S3StatusOK) {
+        std::cout << "Failed to generate authorization header!" << std::endl;
+        std::cout << "Error is " << S3_get_status_name(ret) << std::endl;
+    }
+    struct curl_slist *itr = request->headers;
+    while (itr->next) itr = itr->next;
+    std::cout << (char *)(&itr->data[15]);
+    destroyMockObjs(request, params, values);
+    curl_slist_free_all(headerList);
+    S3_deinitialize();
+    return 0;
+}
+#endif

--- a/test/signature/mock.cpp
+++ b/test/signature/mock.cpp
@@ -1,0 +1,131 @@
+#include <request.h>
+#include <curl/curl.h>
+#include <string>
+#include <string.h>
+#include <libs3.h>
+#include <iostream>
+
+typedef struct RequestComputedValues
+{
+    // All x-amz- headers, in normalized form (i.e. NAME: VALUE, no other ws)
+    char *amzHeaders[S3_MAX_METADATA_COUNT + 2]; // + 2 for acl and date
+
+    // The number of x-amz- headers
+    int amzHeadersCount;
+
+    // Storage for amzHeaders (the +256 is for x-amz-acl and x-amz-date)
+    char amzHeadersRaw[COMPACTED_METADATA_BUFFER_SIZE + 256 + 1];
+
+    // Canonicalized x-amz- headers
+    string_multibuffer(canonicalizedAmzHeaders,
+                       COMPACTED_METADATA_BUFFER_SIZE + 256 + 1);
+
+    // URL-Encoded key
+    char urlEncodedKey[MAX_URLENCODED_KEY_SIZE + 1];
+
+    // Canonicalized resource
+    char canonicalizedResource[MAX_CANONICALIZED_RESOURCE_SIZE + 1];
+
+    // Cache-Control header (or empty)
+    char cacheControlHeader[128];
+
+    // Content-Type header (or empty)
+    char contentTypeHeader[128];
+
+    // Content-MD5 header (or empty)
+    char md5Header[128];
+
+    // Content-Disposition header (or empty)
+    char contentDispositionHeader[128];
+
+    // Content-Encoding header (or empty)
+    char contentEncodingHeader[128];
+
+    // Expires header (or empty)
+    char expiresHeader[128];
+
+    // If-Modified-Since header
+    char ifModifiedSinceHeader[128];
+
+    // If-Unmodified-Since header
+    char ifUnmodifiedSinceHeader[128];
+
+    // If-Match header
+    char ifMatchHeader[128];
+
+    // If-None-Match header
+    char ifNoneMatchHeader[128];
+
+    // Range header
+    char rangeHeader[128];
+
+    // Authorization header
+    char authorizationHeader[128];
+
+    // Host header
+    char hostHeader[128];
+
+    // Time stamp is ISO 8601 format: 'yyyymmddThhmmssZ'
+    char timestamp[32];
+
+    // The signed headers
+    char signedHeaders[COMPACTED_METADATA_BUFFER_SIZE];
+} RequestComputedValues;
+
+HttpRequestType http_verb_to_type(const std::string &verb)
+{
+    if (verb == "POST") return HttpRequestTypePOST;
+    if (verb == "GET") return HttpRequestTypeGET;
+    if (verb == "HEAD") return HttpRequestTypeHEAD;
+    if (verb == "PUT") return HttpRequestTypePUT;
+    return HttpRequestTypeDELETE;
+}
+
+const char *emptysha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+void createMockObjs(const std::string &httpVerb,
+                    const std::string &uri,
+                    const std::string &payloadhash,
+                    struct curl_slist *headers,
+                    Request **request,
+                    RequestParams **params,
+                    RequestComputedValues **values)
+{
+    Request *req = new Request;
+    strncpy(req->uri, uri.c_str(), sizeof(req->uri));
+    req->headers = headers;
+    *request = req;
+    S3PutProperties *putProperties = new S3PutProperties;
+    if (payloadhash.empty())
+        putProperties->md5 = emptysha256;
+    else
+        putProperties->md5 = payloadhash.c_str();
+    RequestParams *par = new RequestParams;
+    par->httpRequestType = http_verb_to_type(httpVerb);
+    par->putProperties = putProperties;
+    par->bucketContext.accessKeyId = "AKIDEXAMPLE";
+    par->bucketContext.secretAccessKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+    *params = par;
+    RequestComputedValues *val = new RequestComputedValues;
+    const char *timestamp = NULL;
+    for (struct curl_slist *itr = headers; itr != NULL; itr = itr->next) {
+        if (!strncmp(itr->data, "X-Amz-Date:", 11)) {
+            timestamp = itr->data + 11;
+            break;
+        }
+    }
+    if (timestamp) {
+        memcpy(val->timestamp, timestamp, 17);
+    }
+    *values = val;
+}
+
+void destroyMockObjs(Request *request,
+                     RequestParams *params,
+                     RequestComputedValues *values)
+{
+    delete request;
+    delete params->putProperties;
+    delete params;
+    delete values;
+}

--- a/test/signature/sign.py
+++ b/test/signature/sign.py
@@ -1,0 +1,20 @@
+import hmac, hashlib
+
+def sign(key, msg):
+    return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
+
+def getSignatureKey(key, dateStamp, regionName, serviceName):
+    kDate = sign(("AWS4" + key).encode("utf-8"), dateStamp)
+    print kDate.encode("hex")
+    kRegion = sign(kDate, regionName)
+    print kRegion.encode("hex")
+    kService = sign(kRegion, serviceName)
+    print kService.encode("hex")
+    kSigning = sign(kService, "aws4_request")
+    return kSigning
+
+print getSignatureKey("wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+                      "20150830",
+                      "us-east-1",
+                      "service").encode("hex")
+                      


### PR DESCRIPTION
S3 requires to use the signature version 4 for authorization in region
Frankfurt and Seoul. So authenticating using AWS signature version 4
is added to libs3 by this commit. Users can choose signature version 4
by pass a "-4" option to s3, for example: s3 -4 list

Only authenticating using an authorization header is supported now.
Authenticating using Query Parameters is not implemented yet.
