### PR TITLE
Fix OSX build error due to uint64_t format string incompatibility

### DIFF
--- a/src/request.c
+++ b/src/request.c
@@ -360,9 +360,9 @@ static S3Status compose_amz_headers(const RequestParams *params,
         }
         // If byteCount != 0 then we're just copying a range, add header
         if (params->byteCount > 0) {
-            headers_append(1, "x-amz-copy-source-range: bytes=%ld-%ld",
-                           params->startByte,
-                           params->startByte + params->byteCount);
+            headers_append(1, "x-amz-copy-source-range: bytes=%llu-%llu",
+                           (unsigned long long)params->startByte,
+                           (unsigned long long)params->startByte + params->byteCount);
         }
         // And the x-amz-metadata-directive header
         if (properties) {


### PR DESCRIPTION
startByte and byteCount variables are explicitly casted to neutral form to avoid incompatibility in uint64_t format string across platforms.

@bji 
