### PR TITLE
Fix minio compatibility. Do not append empty Transfer-Encoding header.

### DIFF
--- a/src/request.c
+++ b/src/request.c
@@ -936,14 +936,8 @@ static S3Status setup_curl(Request *request,
         snprintf(header, sizeof(header), "Content-Length: %llu",
                  (unsigned long long) params->toS3CallbackTotalSize);
         request->headers = curl_slist_append(request->headers, header);
-        request->headers = curl_slist_append(request->headers, 
-                                             "Transfer-Encoding:");
     }
-    else if (params->httpRequestType == HttpRequestTypeCOPY) {
-        request->headers = curl_slist_append(request->headers, 
-                                             "Transfer-Encoding:");
-    }
-    
+
     append_standard_header(hostHeader);
     append_standard_header(cacheControlHeader);
     append_standard_header(contentTypeHeader);


### PR DESCRIPTION
I don't know why `Transfer-Encoding:` is appended, but it seems like the header is silently ignored by curl.
However when S3 auth v4 is used, this header is included to a list of signed headers and breaks authorization. At list for minio.
This PR together with #50 allows to use libs3 with [minio](http://minio.io) server implementation.

My master branch contains both this PR and #50 and works with minio
