### PR TITLE
Fix building error in Ubuntu 12.04

### DIFF
--- a/src/bucket_metadata.c
+++ b/src/bucket_metadata.c
@@ -497,9 +497,9 @@ void generate_content_md5(const char* data, int size,
 
     BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL); //Ignore newlines - write everything in one line
     BIO_write(bio, md5Buffer, sizeof(md5Buffer));
-    BIO_flush(bio);
+    (void) BIO_flush(bio);
     BIO_get_mem_ptr(bio, &bufferPtr);
-    BIO_set_close(bio, BIO_NOCLOSE);
+    (void) BIO_set_close(bio, BIO_NOCLOSE);
 
     if ((unsigned int)retBufferSize + 1 < bufferPtr->length) {
         retBuffer[0] = '\0';


### PR DESCRIPTION
Fix compilation error:

    value computed is not used [-Werror=unused-value]