### PR TITLE
Minor fix for building on macOS Sierra

### DIFF
--- a/GNUmakefile.osx
+++ b/GNUmakefile.osx
@@ -125,7 +125,12 @@ ifndef CFLAGS
     endif
 endif
 
-CFLAGS += -Wall -Werror -Wshadow -Wextra -Iinc \
+# --------------------------------------------------------------------------
+# -Werror breaks the build on the macOS Sierra rendering build unusable 
+# so we use -Wunused-parameter flag instead that will only issue a warning
+# with the newest clang compiler
+
+CFLAGS += -Wall -Wunused-parameter -Wshadow -Wextra -Iinc \
           $(CURL_CFLAGS) $(LIBXML2_CFLAGS) \
           -DLIBS3_VER_MAJOR=\"$(LIBS3_VER_MAJOR)\" \
           -DLIBS3_VER_MINOR=\"$(LIBS3_VER_MINOR)\" \


### PR DESCRIPTION
When compiling with -Werror flag on macOS Sierra there are always unused parameters errors generated by clang compiler. 
Removing the -Werror, and replacing with -Wunused-parameter surpresses the error, and only issues the warning while continuing the building progress. 
