### PR TITLE
extension to support curl_multi_socket_action operation

### DIFF
--- a/inc/libs3.h
+++ b/inc/libs3.h
@@ -1240,6 +1240,28 @@ typedef S3Status (S3MultipartCommitResponseCallback)(const char *location,
                                                      void *callbackData);
 
 
+/**
+ * Mechanism for S3 application to customize each CURL easy request
+ * associated with the given S3 request context.
+ *
+ * This callback can be optinally configured using S3_create_request_context_ex
+ * and will be invoked every time a new CURL request is created in the
+ * context of the given CURLM handle. Invocation will occur after
+ * libs3 has finished configuring its own options of CURL, but before
+ * CURL is started.
+ *
+ * @param curl_multi is the CURLM handle associated with this context.
+ * @param curl_easy is the CURL request being created.
+ * @param setupData is the setupCurlCallbackData parameter passed to
+ *        S3_create_request_context_ex.
+ * @return S3StatusOK to continue processing the request, anything else to
+ *         immediately abort the request and pass this status
+ *         to the S3ResponseCompleteCallback for this request.
+ **/
+typedef S3Status (*S3SetupCurlCallback)(void *curlMulti, void *curlEasy,
+                                        void *setupData);
+
+
 /** **************************************************************************
  * Callback Structures
  ************************************************************************** **/
@@ -1584,6 +1606,51 @@ S3Status S3_create_request_context(S3RequestContext **requestContextReturn);
 
 
 /**
+ * Extended version of S3_create_request_context used to create S3RequestContext
+ * for curl_multi_socket_action CURLM handles that will be managed by libs3 user.
+ * This type of handles offer better performance for applications with large
+ * number of simultaneous connections. For details, see MULTI_SOCKET chapter here:
+ * https://curl.haxx.se/libcurl/c/libcurl-multi.html
+ *
+ * In this mode libs3 user will
+ *  - create its own CURLM using curl_multi_init()
+ *  - configure it for its own handlers using
+ *    CURLMOPT_SOCKETFUNCTION/CURLMOPT_TIMERFUNCTION/etc
+ *  - use S3_create_request_context_ex to create S3RequestContext
+ *    for the above CURLM handle
+ *  - start S3 request
+ *  - every time setupCurlCallback is called, will configure new CURL
+ *    object with its own handlers using
+ *    CURLOPT_OPENSOCKETFUNCTION/CURLOPT_CLOSESOCKETFUNCTION/etc
+ *  - the moment libs3 adds CURL object to CURLM handle, curl will start
+ *    communicating directly with libs3 user to drive socket operations,
+ *    where libs3 user will be responsible for calling curl_multi_socket_action
+ *    when necessary.
+ *  - whenever curl_multi_socket_action indicates change in running_handles
+ *    libs3 user should call S3_process_request_context to let libs3 process
+ *    any completed curl transfers and notify back to libs3 user if that was
+ *    the final transfer for a given S3 request.
+ *
+ * @param requestContextReturn returns the newly-created S3RequestContext
+ *        structure, which if successfully returned, must be destroyed via a
+ *        call to S3_destroy_request_context when it is no longer needed.  If
+ *        an error status is returned from this function, then
+ *        requestContextReturn will not have been filled in, and
+ *        S3_destroy_request_context should not be called on it
+ * @param curlMulti is the CURLM handle to be associated with this context.
+ * @param setupCurlCallback is an optional callback routine to be invoked
+ *        by libs3 every time another CURL request is being created for
+ *        use in this context.
+ * @param setupCurlCallbackData is an opaque data to be passed to
+ *        setupCurlCallback.
+ **/
+S3Status S3_create_request_context_ex(S3RequestContext **requestContextReturn,
+                                      void *curlMulti,
+                                      S3SetupCurlCallback setupCurlCallback,
+                                      void *setupCurlCallbackData);
+
+
+/**
  * Destroys an S3RequestContext which was created with
  * S3_create_request_context.  Any requests which are currently being
  * processed by the S3RequestContext will immediately be aborted and their
@@ -1638,6 +1705,26 @@ S3Status S3_runall_request_context(S3RequestContext *requestContext);
  **/
 S3Status S3_runonce_request_context(S3RequestContext *requestContext,
                                     int *requestsRemainingReturn);
+
+
+/**
+ * Extract and finish requests completed by curl multi handle mechanism
+ * in curl_multi_socket_action mode. Should be called by libs3 user when
+ * curl_multi_socket_action indicates a change in running_handles.
+ *
+ * @param requestContext is the S3RequestContext to process
+ * @return One of:
+ *         S3StatusOK if request processing proceeded without error
+ *         S3StatusConnectionFailed if the socket connection to the server
+ *             failed
+ *         S3StatusServerFailedVerification if the SSL certificate of the
+ *             server could not be verified.
+ *         S3StatusInternalError if an internal error prevented the
+ *             S3RequestContext from running one or more requests
+ *         S3StatusOutOfMemory if requests could not be processed due to
+ *             an out of memory error
+ **/
+S3Status S3_process_request_context(S3RequestContext *requestContext);
 
 
 /**

--- a/inc/request_context.h
+++ b/inc/request_context.h
@@ -29,14 +29,26 @@
 
 #include "libs3.h"
 
+
+typedef enum
+{
+    S3CurlModeMultiPerform                                  ,
+    S3CurlModeMultiSocket                                   ,
+} S3CurlMode;
+
+
 struct S3RequestContext
 {
     CURLM *curlm;
+    S3CurlMode curl_mode;
     
     int verifyPeerSet;
     long verifyPeer;
 
     struct Request *requests;
+
+    S3SetupCurlCallback setupCurlCallback;
+    void *setupCurlCallbackData;
 };
 
 

--- a/src/request_context.c
+++ b/src/request_context.c
@@ -31,7 +31,10 @@
 #include "request_context.h"
 
 
-S3Status S3_create_request_context(S3RequestContext **requestContextReturn)
+S3Status S3_create_request_context_ex(S3RequestContext **requestContextReturn,
+                                      CURLM *curlm,
+                                      S3SetupCurlCallback setupCurlCallback,
+                                      void *setupCurlCallbackData)
 {
     *requestContextReturn = 
         (S3RequestContext *) malloc(sizeof(S3RequestContext));
@@ -40,16 +43,32 @@ S3Status S3_create_request_context(S3RequestContext **requestContextReturn)
         return S3StatusOutOfMemory;
     }
     
-    if (!((*requestContextReturn)->curlm = curl_multi_init())) {
-        free(*requestContextReturn);
-        return S3StatusOutOfMemory;
+    if (curlm) {
+        (*requestContextReturn)->curlm = curlm;
+        (*requestContextReturn)->curl_mode = S3CurlModeMultiSocket;
+    }
+    else {
+        if (!((*requestContextReturn)->curlm = curl_multi_init())) {
+            free(*requestContextReturn);
+            return S3StatusOutOfMemory;
+        }
+
+        (*requestContextReturn)->curl_mode = S3CurlModeMultiPerform;
     }
 
     (*requestContextReturn)->requests = 0;
     (*requestContextReturn)->verifyPeer = 0;
     (*requestContextReturn)->verifyPeerSet = 0;
+    (*requestContextReturn)->setupCurlCallback = setupCurlCallback;
+    (*requestContextReturn)->setupCurlCallbackData = setupCurlCallbackData;
 
     return S3StatusOK;
+}
+
+
+S3Status S3_create_request_context(S3RequestContext **requestContextReturn)
+{
+    return S3_create_request_context_ex(requestContextReturn, NULL, NULL, NULL);
 }
 
 
@@ -68,7 +87,8 @@ void S3_destroy_request_context(S3RequestContext *requestContext)
         r = rNext;
     } while (r != rFirst);
 
-    curl_multi_cleanup(requestContext->curlm);
+    if (requestContext->curl_mode == S3CurlModeMultiPerform)
+        curl_multi_cleanup(requestContext->curlm);
 
     free(requestContext);
 }
@@ -109,10 +129,62 @@ S3Status S3_runall_request_context(S3RequestContext *requestContext)
 }
 
 
+static S3Status process_request_context(S3RequestContext *requestContext, int *retry)
+{
+    CURLMsg *msg;
+    int junk;
+
+    *retry = 0;
+
+    while ((msg = curl_multi_info_read(requestContext->curlm, &junk))) {
+        if (msg->msg != CURLMSG_DONE) {
+            return S3StatusInternalError;
+        }
+        Request *request;
+        if (curl_easy_getinfo(msg->easy_handle, CURLINFO_PRIVATE,
+                              (char **) (char *) &request) != CURLE_OK) {
+            return S3StatusInternalError;
+        }
+        // Remove the request from the list of requests
+        if (request->prev == request->next) {
+            // It was the only one on the list
+            requestContext->requests = 0;
+        }
+        else {
+            // It doesn't matter what the order of them are, so just in
+            // case request was at the head of the list, put the one after
+            // request to the head of the list
+            requestContext->requests = request->next;
+            request->prev->next = request->next;
+            request->next->prev = request->prev;
+        }
+        if ((msg->data.result != CURLE_OK) &&
+            (request->status == S3StatusOK)) {
+            request->status = request_curl_code_to_status(
+                msg->data.result);
+        }
+        if (curl_multi_remove_handle(requestContext->curlm,
+                                     msg->easy_handle) != CURLM_OK) {
+            return S3StatusInternalError;
+        }
+        // Finish the request, ensuring that all callbacks have been made,
+        // and also releases the request
+        request_finish(request);
+        // Now, since a callback was made, there may be new requests
+        // queued up to be performed immediately, so do so
+        *retry = 1;
+    }
+
+    return S3StatusOK;
+}
+
+
 S3Status S3_runonce_request_context(S3RequestContext *requestContext, 
                                     int *requestsRemainingReturn)
 {
+    S3Status s3_status;
     CURLMcode status;
+    int retry;
 
     do {
         status = curl_multi_perform(requestContext->curlm,
@@ -128,50 +200,23 @@ S3Status S3_runonce_request_context(S3RequestContext *requestContext,
             return S3StatusInternalError;
         }
 
-        CURLMsg *msg;
-        int junk;
-        while ((msg = curl_multi_info_read(requestContext->curlm, &junk))) {
-            if (msg->msg != CURLMSG_DONE) {
-                return S3StatusInternalError;
-            }
-            Request *request;
-            if (curl_easy_getinfo(msg->easy_handle, CURLINFO_PRIVATE, 
-                                  (char **) (char *) &request) != CURLE_OK) {
-                return S3StatusInternalError;
-            }
-            // Remove the request from the list of requests
-            if (request->prev == request->next) {
-                // It was the only one on the list
-                requestContext->requests = 0;
-            }
-            else {
-                // It doesn't matter what the order of them are, so just in
-                // case request was at the head of the list, put the one after
-                // request to the head of the list
-                requestContext->requests = request->next;
-                request->prev->next = request->next;
-                request->next->prev = request->prev;
-            }
-            if ((msg->data.result != CURLE_OK) &&
-                (request->status == S3StatusOK)) {
-                request->status = request_curl_code_to_status
-                    (msg->data.result);
-            }
-            if (curl_multi_remove_handle(requestContext->curlm, 
-                                         msg->easy_handle) != CURLM_OK) {
-                return S3StatusInternalError;
-            }
-            // Finish the request, ensuring that all callbacks have been made,
-            // and also releases the request
-            request_finish(request);
-            // Now, since a callback was made, there may be new requests 
-            // queued up to be performed immediately, so do so
-            status = CURLM_CALL_MULTI_PERFORM;
-        }
-    } while (status == CURLM_CALL_MULTI_PERFORM);
+        s3_status = process_request_context(requestContext, &retry);
+    } while (s3_status == S3StatusOK &&
+             (status == CURLM_CALL_MULTI_PERFORM || retry));
 
-    return S3StatusOK;
+    return s3_status;
 }
+
+
+S3Status S3_process_request_context(S3RequestContext *requestContext)
+{
+    int retry;
+    /* In curl_multi_socket_action mode any new requests created during
+       the following call will have already started associated socket
+       operations, so no need to retry here */
+    return process_request_context(requestContext, &retry);
+}
+
 
 S3Status S3_get_request_context_fdsets(S3RequestContext *requestContext,
                                        fd_set *readFdSet, fd_set *writeFdSet,


### PR DESCRIPTION
Make libs3 work with curl_multi_socket_action mode where libs3 user
will drive socket polling instructed directly by curl through a set
of callbacks.

This is an addition to the existing curl_multi_perform mode where libs3
does the polling itself.