### PR TITLE
Fixed noname top directory in S3 bucket if a path begins with /

### DIFF
--- a/src/request.c
+++ b/src/request.c
@@ -796,7 +796,9 @@ static void canonicalize_resource(const S3BucketContext *context,
         }
     }
 
-    append("/");
+    if(*urlEncodedKey != '/') {
+        append("/");
+    }
 
     if (urlEncodedKey && urlEncodedKey[0]) {
         append(urlEncodedKey);
@@ -1111,7 +1113,9 @@ static S3Status compose_uri(char *buffer, int bufferSize,
         uri_append("%s", hostName);
     }
 
-    uri_append("%s", "/");
+    if(*urlEncodedKey != '/') {
+        uri_append("%s", "/");
+    }
 
     uri_append("%s", urlEncodedKey);
 


### PR DESCRIPTION
When a key parameter in S3_put_object function starts with “/“ plus directory name, for example: /directory/…, then a noname top directory is created in the bucket, for example: bucket//directory/… . 
This PR fixes it.
Impact: double "/" is needed to get a noname directory for example: //key.