### PR TITLE
Fix uploading large amounts of data

### DIFF
--- a/src/s3.c
+++ b/src/s3.c
@@ -2201,9 +2201,9 @@ static void put_object(int argc, char **argv, int optindex,
                           CONTENT_LENGTH_PREFIX_LEN)) {
             contentLength = convertInt(&(param[CONTENT_LENGTH_PREFIX_LEN]),
                                        "contentLength");
-            if (contentLength > (5LL * 1024 * 1024 * 1024)) {
+            if (contentLength > (5LL * 1024 * 1024 * 1024 * 1024)) {
                 fprintf(stderr, "\nERROR: contentLength must be no greater "
-                        "than 5 GB\n");
+                        "than 5 TB\n");
                 usageExit(stderr);
             }
         }

--- a/src/s3.c
+++ b/src/s3.c
@@ -2057,7 +2057,7 @@ static int putObjectDataCallback(int bufferSize, char *buffer,
     return ret;
 }
 
-#define MULTIPART_CHUNK_SIZE (15 << 20) // multipart is 15M
+#define MULTIPART_CHUNK_SIZE (768 << 20) // multipart is 768M
 
 typedef struct MultipartPartData {
     put_object_callback_data put_object_data;

--- a/src/s3.c
+++ b/src/s3.c
@@ -426,7 +426,7 @@ typedef struct growbuffer
 // returns nonzero on success, zero on out of memory
 static int growbuffer_append(growbuffer **gb, const char *data, int dataLen)
 {
-    int toCopy = 0 ;
+    int origDataLen = dataLen;
     while (dataLen) {
         growbuffer *buf = *gb ? (*gb)->prev : 0;
         if (!buf || (buf->size == sizeof(buf->data))) {
@@ -448,7 +448,7 @@ static int growbuffer_append(growbuffer **gb, const char *data, int dataLen)
             }
         }
 
-        toCopy = (sizeof(buf->data) - buf->size);
+        int toCopy = (sizeof(buf->data) - buf->size);
         if (toCopy > dataLen) {
             toCopy = dataLen;
         }
@@ -458,7 +458,7 @@ static int growbuffer_append(growbuffer **gb, const char *data, int dataLen)
         buf->size += toCopy, data += toCopy, dataLen -= toCopy;
     }
 
-    return toCopy;
+    return origDataLen;
 }
 
 


### PR DESCRIPTION
When uploading large amounts of data (> 5 GB), libs3 refuses the upload with an error.  This pull request increases the single-object limit to 5 TB, which brings it in line with S3's object limit.

After increasing that limit, a new bug was discovered in growbuffer_append().  The XML produced by put_object() was being truncated if more than one growbuffer was allocated.

If there are any questions about this pull request, please let me know.