### PR TITLE
build: support curl >= 7.62

### DIFF
--- a/src/request.c
+++ b/src/request.c
@@ -1719,7 +1719,9 @@ S3Status request_curl_code_to_status(CURLcode code)
 #else
     case CURLE_SSL_PEER_CERTIFICATE:
 #endif
+#if LIBCURL_VERSION_NUM < 0x073e00
     case CURLE_SSL_CACERT:
+#endif
         return S3StatusServerFailedVerification;
     default:
         return S3StatusInternalError;


### PR DESCRIPTION
libs3 fails to build with 7.62 currently:

    src/request.c: In function 'request_curl_code_to_status':
    src/request.c:1703:5: error: duplicate case value
         case CURLE_SSL_CACERT:
    src/request.c:1699:5: note: previously used here
         case CURLE_PEER_FAILED_VERIFICATION:

Caught by openSUSE.