### PR TITLE
Extract ETag for MPU Part Copy

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -112,7 +112,8 @@ static S3Status copyObjectXmlCallback(const char *elementPath,
         if (!strcmp(elementPath, "CopyObjectResult/LastModified")) {
             string_buffer_append(coData->lastModified, data, dataLen, fit);
         }
-        else if (!strcmp(elementPath, "CopyObjectResult/ETag")) {
+        else if (!strcmp(elementPath, "CopyObjectResult/ETag")
+              || !strcmp(elementPath, "CopyPartResult/ETag")) {
             if (coData->eTagReturnSize && coData->eTagReturn) {
                 coData->eTagReturnLen +=
                     snprintf(&(coData->eTagReturn[coData->eTagReturnLen]),


### PR DESCRIPTION
When an MPU object is created with `x-amz-copy-source`/`x-amz-copy-source-range`,
libs3 was expecting the ETag in `CopyObjectResult/ETag` instead of
`CopyPartResult/ETag`.

Ref: https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPartCopy.html