### PR TITLE
Do not set authorization headers if access key id or secret access key is NULL

### DIFF
--- a/src/request.c
+++ b/src/request.c
@@ -982,6 +982,13 @@ static S3Status compose_auth_header(const RequestParams *params,
     printf("--\nCanonical Request:\n%s\n", canonicalRequest);
 #endif
 
+    if (params->bucketContext.accessKeyId == NULL || params->bucketContext.secretAccessKey == NULL) {
+#ifdef SIGNATURE_DEBUG
+    printf("--\nNo authorization header\n");
+#endif
+      return S3StatusOK;
+    }
+
     len = 0;
     unsigned char canonicalRequestHash[S3_SHA256_DIGEST_LENGTH];
 #ifdef __APPLE__


### PR DESCRIPTION
If bucket is public, allow access without credentials. Functionality is enabled if access key id or secret access key are NULL; in this case the creation of authorization headers is skipped.

Tested only with ```S3_get_object()```.