### PR TITLE
Max length of AWS access key is nowadays 128

### DIFF
--- a/inc/libs3.h
+++ b/inc/libs3.h
@@ -240,6 +240,18 @@ extern "C" {
 #define S3_DEFAULT_REGION                  "us-east-1"
 
 
+/**
+ * Maximal length of AWS access key
+ */
+#define S3_MAX_ACCESS_KEY_ID_LENGTH 128
+
+
+/**
+ * Maximal length of AWS region name
+ */
+#define S3_MAX_REGION_LENGTH 32
+
+
 /** **************************************************************************
  * Enumerations
  ************************************************************************** **/

--- a/inc/util.h
+++ b/inc/util.h
@@ -69,12 +69,10 @@
 #define MAX_CANONICALIZED_RESOURCE_SIZE \
     (1 + 255 + 1 + MAX_URLENCODED_KEY_SIZE + (sizeof("?torrent") - 1) + 1)
 
-#define MAX_ACCESS_KEY_ID_LENGTH 32
-
 // Maximum length of a credential string
 // <access key>/<yyyymmdd>/<region>/s3/aws4_request
 #define MAX_CREDENTIAL_SIZE \
-   (MAX_ACCESS_KEY_ID_LENGTH + 1) + 8 + 1 + 32 + sizeof("/s3/aws4_request")
+   (S3_MAX_ACCESS_KEY_ID_LENGTH + 1) + 8 + 1 + S3_MAX_REGION_LENGTH + sizeof("/s3/aws4_request")
 
 // Utilities -----------------------------------------------------------------
 


### PR DESCRIPTION
See https://docs.aws.amazon.com/IAM/latest/APIReference/API_AccessKey.html

Also exposing the key and region length limit in libs3 API

Based on https://github.com/winscp/winscp/pull/15 by @strima