### PR TITLE
Cannot access S3 bucket root when the access policy checks for empty prefix

### DIFF
--- a/src/bucket.c
+++ b/src/bucket.c
@@ -708,7 +708,7 @@ void S3_list_bucket(const S3BucketContext *bucketContext, const char *prefix,
 
 
     int amp = 0;
-    if (prefix && *prefix) {
+    if (prefix) {
         safe_append("prefix", prefix);
     }
     if (marker && *marker) {


### PR DESCRIPTION
When accessing bucket root, AWS tools send empty prefix (prefix=), contrary to libs3 that sends no prefix. But some AWS policy examples suggest conditions like:
"Condition":{"StringEquals":{"s3:prefix":["","home/"],"s3:delimiter":["/"]}}
With such conditions libs3 will fail to access the root.
Reported for WinSCP:
https://winscp.net/forum/viewtopic.php?t=31359
The same problem for Cyberduck:
https://trac.cyberduck.io/ticket/11549