### PR TITLE
Incomplete listing on Backblaze S3

### DIFF
--- a/src/bucket.c
+++ b/src/bucket.c
@@ -648,10 +648,7 @@ static void listBucketCompleteCallback(S3Status requestStatus,
 {
     ListBucketData *lbData = (ListBucketData *) callbackData;
 
-    // Make the callback if there is anything
-    if (lbData->contentsCount || lbData->commonPrefixesCount) {
-        make_list_bucket_callback(lbData);
-    }
+    make_list_bucket_callback(lbData);
 
     (*(lbData->responseCompleteCallback))
         (requestStatus, s3ErrorDetails, lbData->callbackData);


### PR DESCRIPTION
Contrary to AWS, Backblaze adds `IsTruncated` (and others) only after the `CommonPrefixes` and `Contents`. It's pagination is 1000, what is a multiple of libs3's `MAX_COMMON_PREFIXES`. So if you have prefixes-only listing, you get 125 callbacks with 32 `commonPrefixes` in each. None of them will have valid `isTruncated` yet. And in `listBucketCompleteCallback`, where `isTruncated` is finally known, both `contentsCount` and `commonPrefixesCount` will be zero, and the callback will not be triggered.