### PR TITLE
Fix warnings from curl 8.14

### DIFF
--- a/inc/request.h
+++ b/inc/request.h
@@ -110,7 +110,7 @@ typedef struct RequestParams
     void *callbackData;
 
     // Request timeout. If 0, no timeout will be enforced
-    int timeoutMs;
+    long timeoutMs;
 } RequestParams;
 
 

--- a/src/request.c
+++ b/src/request.c
@@ -55,7 +55,7 @@
 
 //#define SIGNATURE_DEBUG
 
-static int verifyPeer;
+static long verifyPeer;
 
 static char userAgentG[USER_AGENT_SIZE];
 
@@ -1161,7 +1161,7 @@ static S3Status setup_curl(Request *request,
     }
 
     // Debugging only
-    // curl_easy_setopt_safe(CURLOPT_VERBOSE, 1);
+    // curl_easy_setopt_safe(CURLOPT_VERBOSE, 1L);
 
     // Set private data to request for the benefit of S3RequestContext
     curl_easy_setopt_safe(CURLOPT_PRIVATE, request);
@@ -1180,16 +1180,16 @@ static S3Status setup_curl(Request *request,
 
     // Ask curl to parse the Last-Modified header.  This is easier than
     // parsing it ourselves.
-    curl_easy_setopt_safe(CURLOPT_FILETIME, 1);
+    curl_easy_setopt_safe(CURLOPT_FILETIME, 1L);
 
     // Curl docs suggest that this is necessary for multithreaded code.
     // However, it also points out that DNS timeouts will not be honored
     // during DNS lookup, which can be worked around by using the c-ares
     // library, which we do not do yet.
-    curl_easy_setopt_safe(CURLOPT_NOSIGNAL, 1);
+    curl_easy_setopt_safe(CURLOPT_NOSIGNAL, 1L);
 
     // Turn off Curl's built-in progress meter
-    curl_easy_setopt_safe(CURLOPT_NOPROGRESS, 1);
+    curl_easy_setopt_safe(CURLOPT_NOPROGRESS, 1L);
 
     // xxx todo - support setting the proxy for Curl to use (can't use https
     // for proxies though)
@@ -1198,7 +1198,7 @@ static S3Status setup_curl(Request *request,
 
     // I think this is useful - we don't need interactive performance, we need
     // to complete large operations quickly
-    curl_easy_setopt_safe(CURLOPT_TCP_NODELAY, 1);
+    curl_easy_setopt_safe(CURLOPT_TCP_NODELAY, 1L);
 
     // Don't use Curl's 'netrc' feature
     curl_easy_setopt_safe(CURLOPT_NETRC, CURL_NETRC_IGNORED);
@@ -1208,10 +1208,10 @@ static S3Status setup_curl(Request *request,
     curl_easy_setopt_safe(CURLOPT_SSL_VERIFYPEER, verifyPeer);
 
     // Follow any redirection directives that S3 sends
-    curl_easy_setopt_safe(CURLOPT_FOLLOWLOCATION, 1);
+    curl_easy_setopt_safe(CURLOPT_FOLLOWLOCATION, 1L);
 
     // A safety valve in case S3 goes bananas with redirects
-    curl_easy_setopt_safe(CURLOPT_MAXREDIRS, 10);
+    curl_easy_setopt_safe(CURLOPT_MAXREDIRS, 10L);
 
     // Set the User-Agent; maybe Amazon will track these?
     curl_easy_setopt_safe(CURLOPT_USERAGENT, userAgentG);
@@ -1220,8 +1220,8 @@ static S3Status setup_curl(Request *request,
     // less than 1K per second for more than 15 seconds.
     // xxx todo - make these configurable
     // xxx todo - allow configurable max send and receive speed
-    curl_easy_setopt_safe(CURLOPT_LOW_SPEED_LIMIT, 1024);
-    curl_easy_setopt_safe(CURLOPT_LOW_SPEED_TIME, 15);
+    curl_easy_setopt_safe(CURLOPT_LOW_SPEED_LIMIT, 1024L);
+    curl_easy_setopt_safe(CURLOPT_LOW_SPEED_TIME, 15L);
 
 
     if (params->timeoutMs > 0) {
@@ -1281,16 +1281,16 @@ static S3Status setup_curl(Request *request,
     // Set request type.
     switch (params->httpRequestType) {
     case HttpRequestTypeHEAD:
-        curl_easy_setopt_safe(CURLOPT_NOBODY, 1);
+        curl_easy_setopt_safe(CURLOPT_NOBODY, 1L);
         break;
     case HttpRequestTypePOST:
         curl_easy_setopt_safe(CURLOPT_CUSTOMREQUEST, "POST");
-        curl_easy_setopt_safe(CURLOPT_UPLOAD, 1);
+        curl_easy_setopt_safe(CURLOPT_UPLOAD, 1L);
         break;
 
     case HttpRequestTypePUT:
     case HttpRequestTypeCOPY:
-        curl_easy_setopt_safe(CURLOPT_UPLOAD, 1);
+        curl_easy_setopt_safe(CURLOPT_UPLOAD, 1L);
         break;
     case HttpRequestTypeDELETE:
         curl_easy_setopt_safe(CURLOPT_CUSTOMREQUEST, "DELETE");


### PR DESCRIPTION
src/request.c:1158:19: error: call to ‘_curl_easy_setopt_err_long’ declared with attribute warning: curl_easy_setopt expects a long argument [-Werror=attribute-warning]