### PR TITLE
Fix compilation on systems with larger utsname field sizes

### DIFF
--- a/src/request.c
+++ b/src/request.c
@@ -49,7 +49,8 @@
 #define S3_SHA256_DIGEST_LENGTH SHA256_DIGEST_LENGTH
 #endif
 
-#define USER_AGENT_SIZE 256
+#define USER_AGENT_SIZE 126 + sizeof(((struct utsname*)0)->sysname) \
+                            + sizeof(((struct utsname*)0)->machine)
 #define REQUEST_STACK_SIZE 32
 #define SIGNATURE_SCOPE_SIZE 64
 


### PR DESCRIPTION
On Linux the sizes of the sysname and machine fields are 65 bytes and the target array is large enough to hold the result of the snprintf command.

On platforms where the sizes of the fields are larger, e.g. GNY/Hurd where they are 1024 bytes, the results overflows.
```
src/request.c:1105:57: error: ‘%s’ directive output may be truncated writing up to 2048 bytes into a region of size between 211 and 218 [-Werror=format-truncation=]
```
This change does not change the size of the array on Linux: 126 + 65 + 65 = 256
